### PR TITLE
Fix failing build on macos

### DIFF
--- a/src/libc_ext.rs
+++ b/src/libc_ext.rs
@@ -1,6 +1,13 @@
 use libc;
 
+#[cfg(target_os="macos")]
+pub const TIOCGWINSZ: libc::c_ulonglong = 0x5413;
+#[cfg(target_os="macos")]
+pub const TIOCSWINSZ: libc::c_ulonglong = 0x5414;
+
+#[cfg(target_os="linux")]
 pub const TIOCGWINSZ: libc::c_int = 0x5413;
+#[cfg(target_os="linux")]
 pub const TIOCSWINSZ: libc::c_int = 0x5414;
 
 #[repr(C)]


### PR DESCRIPTION
``` console
[kawaguchi:~/src/github.com/idobata/hokaido](hakodate)> cargo build
   Compiling hokaido v0.0.2 (file:///Users/hrysd/src/github.com/idobata/hokaido)
src/winsize.rs:9:24: 9:34 error: mismatched types:
 expected `u64`,
    found `i32`
(expected u64,
    found i32) [E0308]
src/winsize.rs:9     unsafe { ioctl(fd, TIOCGWINSZ, &winsize) };
                                        ^~~~~~~~~~
src/winsize.rs:9:24: 9:34 help: run `rustc --explain E0308` to see a detailed explanation
src/winsize.rs:15:24: 15:34 error: mismatched types:
 expected `u64`,
    found `i32`
(expected u64,
    found i32) [E0308]
src/winsize.rs:15     unsafe { ioctl(fd, TIOCSWINSZ, winsize); };
                                         ^~~~~~~~~~
src/winsize.rs:15:24: 15:34 help: run `rustc --explain E0308` to see a detailed explanation
error: aborting due to 2 previous errors
Could not compile `hokaido`.

To learn more, run the command again with --verbose.
```
