### PR TITLE
bump libc version to fix warning in rustc v1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ['terminal', 'tool']
 
 [dependencies]
 docopt='0.6'
-libc='0.1.8'
+libc='0.2.6'
 nix='0.3.9'
 pty='0.1.6'
 pty-shell='0.1.3'


### PR DESCRIPTION
libc(0.1.12) has warning to use rustc(v1.6).

```
.cargo/registry/src/github.com-88ac128001ac3a9a/libc-0.1.12/rust/src/liblibc/lib.rs:81:21:
81:39 warning: lint raw_pointer_derive has been removed: using derive
with raw pointers is ok
```
