### PR TITLE
bump rmp-serialize version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ log = '0.3'
 nix='0.5.0'
 pty='0.1.6'
 pty-shell='0.1.3'
-rmp-serialize = '0.7'
+rmp-serialize = '0.8'
 rustc-serialize='0.3'
 termios='0.2.0'
 clippy = {version = '0.0', optional = true}


### PR DESCRIPTION
I update rmp-serialize version to compile by Rust 1.14.0.
Because, I can't compile it.

```
$ cargo build
<< snip >>
error[E0432]: unresolved import `rmp::decode::ReadError`
  --> /Users/takkanm/.cargo/registry/src/github.com-1ecc6299db9ec823/rmp-serialize-0.7.0/src/decode.rs:10:5
   |
10 |     ReadError,
   |     ^^^^^^^^^ no `ReadError` in `rmp::decode`
<< snip >>
```